### PR TITLE
ValueError: Namespace Notify not available for version 0.7

### DIFF
--- a/prayertime.py
+++ b/prayertime.py
@@ -27,7 +27,7 @@ __all__ = ['Calendar', 'Prayertime', 'Madhab', 'as_pytime', 'as_pydatetime']
 
 import gi
 gi.require_version('Gtk', '3.0')
-gi.require_version('Notify', '0.7')
+gi.require_version('Notify', '0.8')
 from gi.repository import Gtk, Gst, GObject, Gio, GLib, GdkPixbuf, Notify
 from math import degrees, radians, atan, atan2, asin, acos, cos, sin, tan, fabs 
 from datetime import date, timedelta


### PR DESCRIPTION
I'm using archlinux (idk for other distros) I recently did 'pacman -Syu' to update all packages and got this error

modifying 'Notify' from 0.7 to 0.8 fixed the issue