### PR TITLE
Remove 'require_version' to fix version issue

### DIFF
--- a/prayertime.py
+++ b/prayertime.py
@@ -26,12 +26,7 @@ __author__ = "Jesse Wayde Brandão (Abdul Hakim)"
 __all__ = ['Calendar', 'Prayertime', 'Madhab', 'as_pytime', 'as_pydatetime']
 
 import gi
-import distro
 gi.require_version('Gtk', '3.0')
-if distro.id() == 'arch':
-    gi.require_version('Notify', '0.8')
-else:
-    gi.require_version('Notify', '0.7')
 from gi.repository import Gtk, Gst, GObject, Gio, GLib, GdkPixbuf, Notify
 from math import degrees, radians, atan, atan2, asin, acos, cos, sin, tan, fabs 
 from datetime import date, timedelta


### PR DESCRIPTION
Salam, it's me again

So to start, I made a PR a while ago to change Notify version from 0.7 to 0.8 to fix some version issue on different distros

But that didn't stop the problem, the correct version code can sometimes be 0.7 or 0.8 and can change while using the same distro for some reason

This can be fixed by removing the entire line requiring version 0.7/0.8, that way it'll load Notify aside from it's version number